### PR TITLE
Removed reference to moment library

### DIFF
--- a/gettext.js
+++ b/gettext.js
@@ -81,7 +81,6 @@ if (typeof Object.assign != 'function') {
 
     global.setLanguage = function (newLanguageCode) {
         global.languageCode = newLanguageCode;
-        moment.locale(newLanguageCode);
     };
     global.setLanguage('en');
 


### PR DESCRIPTION
Including this reference to the moment library introduces an extremely undesirable side-effect and/or a bug that could easily break any app that uses this library (assuming that it does not include the moment library itself).

This removes the single reference to the moment.js library.
Calling projects/apps will need to do the call to moment.locale themselves (as they should).